### PR TITLE
feat: add customMedia option to media-prefers-reduced-motion

### DIFF
--- a/src/rules/media-prefers-reduced-motion/README.md
+++ b/src/rules/media-prefers-reduced-motion/README.md
@@ -58,3 +58,34 @@ div {
   }
 }
 ```
+
+## Optional secondary options
+
+### `customMedia: "--custom-media-name" | ["--custom-media-name", ...]`
+
+Name(s) of [custom media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/@custom-media) that should be treated as a `prefers-reduced-motion` media query:
+
+```json
+{
+  "a11y/media-prefers-reduced-motion": [true, { "customMedia": "--motionReduce" }]
+}
+```
+
+```css
+@custom-media --motionReduce screen and (prefers-reduced-motion: reduce);
+```
+
+With this option the following pattern is _not_ considered a violation:
+
+```css
+.foo {
+  transition: all 0.2s ease;
+}
+@media (--motionReduce) {
+  .foo {
+    transition: none;
+  }
+}
+```
+
+The `--fix` option will use the first custom media name for the inserted media query.

--- a/src/rules/media-prefers-reduced-motion/index.js
+++ b/src/rules/media-prefers-reduced-motion/index.js
@@ -2,6 +2,7 @@ import isCustomSelector from 'stylelint/lib/utils/isCustomSelector.mjs'
 import isStandardSyntaxAtRule from 'stylelint/lib/utils/isStandardSyntaxAtRule.mjs'
 import isStandardSyntaxRule from 'stylelint/lib/utils/isStandardSyntaxRule.mjs'
 import isStandardSyntaxSelector from 'stylelint/lib/utils/isStandardSyntaxSelector.mjs'
+import { isString } from 'stylelint/lib/utils/validateTypes.mjs'
 import { parse } from 'postcss'
 import stylelint from 'stylelint'
 
@@ -19,7 +20,11 @@ const targetProperties = [
   'animation-name'
 ]
 
-function checkChildrenNodes(childrenNodes, currentSelector, parentNode) {
+function checkChildrenNodes(childrenNodes, currentSelector, parentNode, matchesReducedMotion) {
+  if (!matchesReducedMotion(parentNode.params)) {
+    return false
+  }
+
   return childrenNodes.some((declaration) => {
     const index = targetProperties.indexOf(declaration.prop)
 
@@ -35,11 +40,11 @@ function checkChildrenNodes(childrenNodes, currentSelector, parentNode) {
       return false
     }
 
-    return index >= 0 && parentNode.params.indexOf('prefers-reduced-motion') >= 0
+    return index >= 0
   })
 }
 
-function check(selector, node) {
+function check(selector, node, matchesReducedMotion) {
   const declarations = node.nodes
   const params = node.parent.params
   const parentNodes = node.parent.nodes
@@ -58,7 +63,7 @@ function check(selector, node) {
 
   let currentSelector = null
   const declarationsIsMatched = declarations.some((declaration) => {
-    const noMatchedParams = !params || params.indexOf('prefers-reduced-motion') === -1
+    const noMatchedParams = !params || !matchesReducedMotion(params)
     const index = targetProperties.indexOf(declaration.prop)
 
     currentSelector = targetProperties[index]
@@ -85,7 +90,7 @@ function check(selector, node) {
 
         if (
           childrenNode.type === 'atrule'
-          && childrenNode.params.indexOf('prefers-reduced-motion') >= 0
+          && matchesReducedMotion(childrenNode.params)
         ) {
           return childrenNodes.some((declaration) => {
             const index = targetProperties.indexOf(declaration.prop)
@@ -114,7 +119,7 @@ function check(selector, node) {
           return false
         }
 
-        return checkChildrenNodes(childrenNodes, currentSelector, parentNode)
+        return checkChildrenNodes(childrenNodes, currentSelector, parentNode, matchesReducedMotion)
       })
     })
 
@@ -128,15 +133,28 @@ function check(selector, node) {
   return true
 }
 
-export default function mediaPrefersReducedMotion(actual, _, context) {
+export default function mediaPrefersReducedMotion(actual, secondaryOptions, context) {
   return (root, result) => {
     const validOptions = validateOptions(result, ruleName, {
       actual
+    }, {
+      actual: secondaryOptions,
+      possible: {
+        customMedia: [isString]
+      },
+      optional: true
     })
 
     if (!validOptions || !actual) {
       return
     }
+
+    const customMedia = [secondaryOptions?.customMedia ?? []].flat()
+    const matchesReducedMotion = params => params.includes('prefers-reduced-motion')
+      || customMedia.some(name => params.includes(name))
+    const fixMediaQuery = customMedia.length
+      ? `(${customMedia[0]})`
+      : 'screen and (prefers-reduced-motion: reduce)'
 
     root.walk((node) => {
       let selector = null
@@ -159,10 +177,10 @@ export default function mediaPrefersReducedMotion(actual, _, context) {
         return
       }
 
-      const isAccepted = check(selector, node)
+      const isAccepted = check(selector, node, matchesReducedMotion)
 
       if (context.fix && !isAccepted) {
-        const media = parse('\n@media screen and (prefers-reduced-motion: reduce) {}')
+        const media = parse(`\n@media ${fixMediaQuery} {}`)
 
         media.nodes.forEach((o) => {
           o.raws.after = '\n'

--- a/src/rules/media-prefers-reduced-motion/index.spec.js
+++ b/src/rules/media-prefers-reduced-motion/index.spec.js
@@ -66,3 +66,76 @@ testRule({
     }
   ]
 })
+
+testRule({
+  plugins,
+  ruleName,
+  config: [
+    true,
+    {
+      customMedia: '--motionReduce'
+    }
+  ],
+  fix: true,
+
+  accept: [
+    {
+      code: '.foo { transition: none } @media (--motionReduce) { .foo { transition: none } }'
+    },
+    {
+      code: '.foo { transition: all; @media (--motionReduce) { transition: none; } }'
+    },
+    {
+      code: '.foo { transition: none } @media screen and (prefers-reduced-motion: reduce) { .foo { transition: none } }'
+    },
+    {
+      code: 'a { animation-name: skew; } @media (--motionReduce) { a { animation: none } }'
+    }
+  ],
+
+  reject: [
+    {
+      code: '.foo { transition: all 5s; color: red; }',
+      fixed: '.foo { transition: all 5s; color: red; }\n@media (--motionReduce) {\n.foo { transition: none;\n}\n}',
+      message: messages.expected('.foo'),
+      line: 1,
+      column: 3
+    },
+    {
+      code: 'a { animation-name: skew; } @media (--anotherMedia) { a { animation: none } }',
+      fixed: 'a { animation-name: skew; }\n@media (--motionReduce) {\na { animation: none;\n}\n} @media (--anotherMedia) { a { animation: none } }',
+      message: messages.expected('a'),
+      line: 1,
+      column: 3
+    }
+  ]
+})
+
+testRule({
+  plugins,
+  ruleName,
+  config: [
+    true,
+    {
+      customMedia: ['--motionReduce', '--reducedMotion']
+    }
+  ],
+
+  accept: [
+    {
+      code: '.foo { transition: none } @media (--reducedMotion) { .foo { transition: none } }'
+    },
+    {
+      code: '.foo { transition: all; @media (--motionReduce) { transition: none; } }'
+    }
+  ],
+
+  reject: [
+    {
+      code: '.foo { animation: 1s ease-in; }',
+      message: messages.expected('.foo'),
+      line: 1,
+      column: 3
+    }
+  ]
+})


### PR DESCRIPTION
## What

- Add `customMedia` secondary option to the `a11y/media-prefers-reduced-motion` rule: name(s) of custom media queries (e.g. `--motionReduce`) that should be treated as a `prefers-reduced-motion` media query.
- The fixer inserts `@media (--name) { ... }` with the first configured name when the option is set.
- Fix: `animation-name` → `animation: none` compensation was accepted from any at-rule regardless of its media params.

## Why

Projects using `@custom-media` (postcss-custom-media) alias the reduced-motion query, e.g.:

```css
@custom-media --motionReduce screen and (prefers-reduced-motion: reduce);
```

The rule only matched the literal `prefers-reduced-motion` string, so such projects had to disable it.

## Usage

```json
{
  "a11y/media-prefers-reduced-motion": [true, { "customMedia": "--motionReduce" }]
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)